### PR TITLE
fix overflow errors on safari

### DIFF
--- a/style/header.scss
+++ b/style/header.scss
@@ -135,7 +135,7 @@ $header-height: 92px;
     .hamburger-links {
         position: fixed;
         display: flex;
-        flex-flow: column wrap;
+        flex-flow: row wrap;
         width: 100%;
         height: 100%;
         z-index: 200;
@@ -184,6 +184,7 @@ $header-height: 92px;
 
                 img {
                     height: 100%;
+                    max-height: 60px;
                 }
             }
 
@@ -200,7 +201,7 @@ $header-height: 92px;
             .footer {
                 display: flex;
                 background-color: white;
-                flex-flow: row nowrap;
+                flex-flow: row-reverse nowrap;
                 padding: 0rem;
                 flex-grow: 1;
                 align-items: flex-end;

--- a/style/header.scss
+++ b/style/header.scss
@@ -191,6 +191,7 @@ $header-height: 92px;
             a {
                 margin-top: 3rem;
                 color: #70808D;
+                flex-grow: 1;
             }
 
             // img {
@@ -201,10 +202,9 @@ $header-height: 92px;
             .footer {
                 display: flex;
                 background-color: white;
-                flex-flow: row-reverse nowrap;
+                flex-flow: row nowrap;
                 padding: 0rem;
-                flex-grow: 1;
-                align-items: flex-end;
+                justify-content: flex-start;
 
                 * {
                     margin: 0px !important;


### PR DESCRIPTION
closes #28

Were two issues here:

- `.hamburger-links` should have been row vs column
- image 100% inside a div with max-height will still make the image full size (gets constrained in chrome)